### PR TITLE
Cache ::getPropertyValue

### DIFF
--- a/src/scoped-property-store.coffee
+++ b/src/scoped-property-store.coffee
@@ -37,21 +37,22 @@ class ScopedPropertyStore
   # keyPath - A `.` separated string of keys to traverse in the properties.
   #
   # Returns the property value or `undefined` if none is found.
-  getPropertyValue: (scopeChain, keyPath) ->
-    candidateSets = @propertySets.filter (set) -> set.has(keyPath)
-    return unless candidateSets.length > 0
+  getPropertyValue: (originalScopeChain, keyPath) ->
+    return @getCachedValue(originalScopeChain, keyPath) if @hasCachedValue(originalScopeChain, keyPath)
 
-    scopeChain = @parseScopeChain(scopeChain)
+    scopeChain = @parseScopeChain(originalScopeChain)
     while scopeChain.length > 0
-      matchingSets = candidateSets
-        .filter (set) -> set.matches(scopeChain)
+      matchingSets = @propertySets
+        .filter (set) -> set.matches(scopeChain) and set.has(keyPath)
         .sort (a, b) -> a.compare(b)
       if matchingSets.length > 0
-        return matchingSets[0].get(keyPath)
+        return @setCachedValue(scopeChain, keyPath, matchingSets[0].get(keyPath))
       else
         scopeChain.pop()
 
-    undefined
+    # We need to cache that we do not have the value, otherwise when the store
+    # does not have the value, we'll always miss the cache.
+    @setCachedValue(originalScopeChain, keyPath, undefined)
 
   # Public: Get *all* property objects matching the given scope chain that
   # contain a value for given key path.
@@ -110,12 +111,27 @@ class ScopedPropertyStore
         merged[propertySet.selector] = propertySet
     merged
 
+  hasCachedValue: (scopeChain, keyPath) ->
+    return false unless @cache? and "#{scopeChain}:#{keyPath}" of @cache
+    true
+
+  getCachedValue: (scopeChain, keyPath) ->
+    @cache ?= {}
+    @cache["#{scopeChain}:#{keyPath}"]
+
+  setCachedValue: (scopeChain, keyPath, value) ->
+    @cache ?= {}
+    @cache["#{scopeChain}:#{keyPath}"] = value
+
+  bustCache: ->
+    @cache = null
 
   addPropertySet: (propertySet) ->
     @propertySets.push(propertySet)
     new Disposable =>
       index = @propertySets.indexOf(propertySet)
       @propertySets.splice(index, 1) if index > -1
+      @bustCache()
 
   parseScopeChain: (scopeChain) ->
     scopeChain = scopeChain.replace @escapeCharacterRegex, (match) -> "\\#{match[0]}"


### PR DESCRIPTION
This has been tuned a bit. Caches values that are in the store and, maybe more importantly, caches when values are not in the store.

On a cache miss, the slow part is _.hasKeyPath().

Time pulling scoped properties on a 500 line file was reduced from 150ms -> 10ms. 

When we go deep on perf, this will prolly become a bottleneck, but is the least of the concerns at this point (deprecations take ~120ms in dev mode for this file).
