### PR TITLE
Group property sets into mutable layers

### DIFF
--- a/spec/scoped-property-store-spec.coffee
+++ b/spec/scoped-property-store-spec.coffee
@@ -6,9 +6,45 @@ describe "ScopedPropertyStore", ->
   beforeEach ->
     store = new ScopedPropertyStore
 
+  describe "::addLayer(name, {priority})", ->
+    it "adds the layer to the cascade, positioned according to its priority", ->
+      expect(store.getLayers()).toEqual([])
+
+      layer1 = store.addLayer('first-source', priority: Infinity)
+      layer2 = store.addLayer('second-source', priority: 1)
+      layer3 = store.addLayer('third-source', priority: 2)
+
+      expect(store.getLayers()).toEqual([layer2, layer3, layer1])
+
+    it "assumes a default priority of zero", ->
+      layer1 = store.addLayer('first-source', priority: 1)
+      layer2 = store.addLayer('third-source', priority: -1)
+      layer3 = store.addLayer('second-source')
+
+      expect(store.getLayers()).toEqual([layer2, layer3, layer1])
+
+    it "allows the layer to later be retrieved by name", ->
+      expect(store.getLayer('first-layer')).toBeUndefined()
+      layer = store.addLayer('first-layer')
+      expect(store.getLayer('first-layer')).toBe(layer)
+
+    it "allows the layer to later be destroyed", ->
+      layer = store.addLayer('first-layer')
+      layer.destroy()
+      expect(store.getLayers()).toEqual([])
+
+    describe "when a layer with the given name already exists", ->
+      it "reassigns the layer's priority and returns it", ->
+        layer1 = store.addLayer('x', priority: 2)
+        layer2 = store.addLayer('y')
+        expect(store.getLayers()).toEqual([layer2, layer1])
+
+        expect(store.addLayer('x', priority: -1)).toBe(layer1)
+        expect(store.getLayers()).toEqual([layer1, layer2])
+
   describe "::getPropertyValue(scopeChain, keyPath)", ->
     it "returns the property with the most specific scope selector for the given scope chain", ->
-      store.addProperties 'test',
+      store.addLayer('test').set
         '.c': {x: y: 3}
         '.b .c': {x: y: 2}
         '.a .b .c': {x: y: 1}
@@ -20,7 +56,7 @@ describe "ScopedPropertyStore", ->
       expect(store.getPropertyValue('.other .stuff .c', 'x.y')).toBe 3
 
     it "returns properties that match parent scopes if none match the exact scope", ->
-      store.addProperties 'test',
+      store.addLayer('test').set
         '.a .b.c': {x: y: 3}
         '.d.e': {x: y: 2}
         '.f': {x: y: 1}
@@ -31,32 +67,34 @@ describe "ScopedPropertyStore", ->
       expect(store.getPropertyValue('.y', 'x.y')).toBeUndefined()
 
     it "deep-merges all values for the given key path", ->
-      store.addProperties('test', '.a': {t: u: v: 1})
-      store.addProperties('test', '.a .b': {t: u: w: 2})
-      store.addProperties('test', '.a .b .c': {t: x: 3})
+      store.addLayer('test').set
+        '.a': {t: u: v: 1}
+        '.a .b': {t: u: w: 2}
+        '.a .b .c': {t: x: 3}
+
       expect(store.getPropertyValue('.a .b .c', 't.u')).toEqual {v: 1, w: 2}
       expect(store.getPropertyValue('.a .b .c', 't')).toEqual {u: {v: 1, w: 2}, x: 3}
       expect(store.getPropertyValue('.a .b .c', null)).toEqual {t: {u: {v: 1, w: 2}, x: 3}}
 
-      store.addProperties('test', '.a .b .c': {t: u: false})
+      store.getLayer('test').set('.a .b .c': {t: u: false})
       expect(store.getPropertyValue('.a .b .c', 't.u')).toBe false
       expect(store.getPropertyValue('.a .b .c', 't')).toEqual {u: false, x: 3}
       expect(store.getPropertyValue('.a .b .c', null)).toEqual {t: {u: false, x: 3}}
 
-      store.addProperties('test', '.a .b .c': {t: null})
+      store.getLayer('test').set('.a .b .c': {t: null})
       expect(store.getPropertyValue('.a .b .c', 't.u')).toEqual undefined
       expect(store.getPropertyValue('.a .b .c', 't')).toEqual null
       expect(store.getPropertyValue('.a .b .c', null)).toEqual {t: null}
 
-    it "favors the most recently added properties in the event of a specificity tie", ->
-      store.addProperties('test', '.a.b .c': 'x': 1)
-      store.addProperties('test', '.a .c.d': 'x': 2)
+    it "favors the most recently added layers in the event of a specificity and priority tie", ->
+      store.addLayer('test1', priority: 1).set('.a.b .c': 'x': 1)
+      store.addLayer('test2', priority: 1).set('.a .c.d': 'x': 2)
 
       expect(store.getPropertyValue('.a.b .c.d', 'x')).toBe 2
       expect(store.getPropertyValue('.a.b .c', 'x')).toBe 1
 
     it "escapes non-whitespace combinators in the scope chain", ->
-      store.addProperties 'test',
+      store.addLayer('test').set
         '.c\\+\\+': a: 1
         '.c\\>': a: 2
         '.c\\~': a: 3
@@ -116,33 +154,33 @@ describe "ScopedPropertyStore", ->
       expect(store.getPropertyValue('.c]', 'a')).toBe 28
       expect(store.getPropertyValue('()', 'a')).toBeUndefined()
 
-    describe 'when priority option is used to add properties', ->
-      it "returns the property with the highest priority", ->
-        store.addProperties 'test1', '.a.b': {x: y: 1}, {priority: 100}
-        store.addProperties 'test2', '.a.b': {x: y: 2}
-        store.addProperties 'test3', '.a.b': {x: y: 3}
+    it "favors higher-priority layers in the event of a specificity tie", ->
+      store.addLayer('test2').set('.a.b': {x: y: 2})
+      store.addLayer('test1', priority: 100).set('.a.b': {x: y: 1})
+      store.addLayer('test3').set('.a.b': {x: y: 3})
 
-        expect(store.getPropertyValue('.a.b', 'x.y')).toBe 1
+      expect(store.getPropertyValue('.a.b', 'x.y')).toBe 1
 
-    describe "when the 'sources' option is provided", ->
-      it "returns property values from the specified source", ->
-        store.addProperties 'test1', '.a.b': {x: y: 1}
-        store.addProperties 'test2', '.a.b': {x: y: 2}
-        store.addProperties 'test3', '.a.b': {x: y: 3}
+    describe "when the 'includeLayers' option is provided", ->
+      it "returns property values from the specified layers", ->
+        store.addLayer('test1').set('.a.b': {x: y: 1})
+        store.addLayer('test2').set('.a.b': {x: y: 2})
+        store.addLayer('test3', priority: 100).set('.a.b': {x: y: 3})
 
-        expect(store.getPropertyValue('.a.b', 'x.y', sources: ['test1'])).toBe 1
+        expect(store.getPropertyValue('.a.b', 'x.y', includeLayers: ['test1'])).toBe 1
         expect(store.getPropertyValue('.a.b', 'x.y')).toBe 3 # shouldn't cache the previous call
 
-    describe "when the 'excludeSources' options is used", ->
-      it "returns properties set on sources excluding the source secified", ->
-        store.addProperties 'test1', '.a.b': {x: y: 1}
-        store.addProperties 'test2', '.a.b': {x: y: 2}
-        store.addProperties 'test3', '.a.b': {x: y: 3}
+    describe "when the 'excludeLayers' options is used", ->
+      it "returns properties set on sources excluding the layers specified", ->
+        store.addLayer('test1').set('.a.b': {x: y: 1})
+        store.addLayer('test2', priority: 50).set('.a.b': {x: y: 2})
+        store.addLayer('test3', priority: 100).set('.a.b': {x: y: 3})
 
-        expect(store.getPropertyValue('.a.b', 'x.y', excludeSources: ['test3'])).toBe 2
+        expect(store.getPropertyValue('.a.b', 'x.y', excludeLayers: ['test3'])).toBe 2
+        expect(store.getPropertyValue('.a.b', 'x.y', excludeLayers: ['test2', 'test3'])).toBe 1
         expect(store.getPropertyValue('.a.b', 'x.y')).toBe 3 # shouldn't cache the previous call
 
-  describe "::getProperties(scopeChain, keyPath)", ->
+  describe "deprecated ::getProperties(scopeChain, keyPath)", ->
     beforeEach ->
       store.addProperties 'test',
         '.a .b .c.d': x: 1, y: 2
@@ -153,16 +191,12 @@ describe "ScopedPropertyStore", ->
       store.addProperties 'test',
         '.a .b .c': q: 4
 
-    describe "when a keyPath is provided", ->
-      it "gets all properties matching the given scope that contain the given key path, ordered by specificity", ->
-        expect(store.getProperties('.a .b .c.d', 'x')).toEqual [{x: 1, y: 2}, {x: 2}, {x: undefined}, {x: 3}]
-
     describe "when no keyPath is provided", ->
       it "gets all properties matching the given scope", ->
-        expect(store.getProperties('.a .b .c.d')).toEqual [{x: 1, y: 2}, {q: 4}, {x: 2}, {x: undefined}, {x: 3}]
+        expect(store.getProperties('.a .b .c.d')).toEqual [{x: 1, y: 2, q: 4}]
 
   describe "removing properties", ->
-    describe "when ::removePropertiesForSource(source, selector) is used", ->
+    describe "when ::removePropertiesForSource(source) is used", ->
       it "removes properties previously added with ::addProperties", ->
         store.addProperties('test1', '.a.b': 'x': 1)
         store.addProperties('test2', '.a': 'x': 2)
@@ -261,7 +295,7 @@ describe "ScopedPropertyStore", ->
 
       expect(store.propertiesForSourceAndSelector('b', '.o.k')).toEqual y: 5, z: 3
 
-  describe "::propertiesForSourceAndSelector(source, selector)", ->
+  describe "::propertiesForSelector(selector)", ->
     it 'returns all the properties for a given source', ->
       store.addProperties('a', '.a.b': 'x': 1)
       store.addProperties('b', '.a': 'x': 2)

--- a/src/layer.coffee
+++ b/src/layer.coffee
@@ -1,0 +1,62 @@
+{deepExtend, find} = require 'underscore-plus'
+PropertySet = require './property-set'
+Selector = require './selector'
+
+# Public: A single layer of scoped properties in a cascade - analogous to a
+# single stylesheet on a web page.
+module.exports =
+class Layer
+  constructor: (@name, @priority, @counter, @owner) ->
+    @propertySets = []
+
+  # Public: Add or update properties in the {Layer}.
+  #
+  # * `propertiesBySelector` An {Object} whose keys are scope selector {String}s
+  #   and whose values are {Object}s representing properties values to store.
+  set: (propertiesBySelector) ->
+    for selectorString, properties of propertiesBySelector
+      for selector in Selector.create(selectorString)
+        propertySet = find @propertySets, (set) ->
+          set.selector.isEqual(selector)
+        unless propertySet?
+          propertySet = new PropertySet(selector, this)
+          @propertySets.push(propertySet)
+        deepExtend(propertySet.properties, properties)
+    @owner.layerDidUpdate(this)
+
+  # Public: Remove properties from the {Layer}.
+  #
+  # * `scopeSelector` A scope selector {String} from which to remove properties
+  #   whose values were previously assigned using {::set}.
+  # * `keyPath` (optional) A key-path {String} representing a subset of the
+  #   properties to remove. If not provided, all properties for the selector
+  #   will be removed.
+  unset: (scopeSelector, keyPath) ->
+    for selector in Selector.create(scopeSelector)
+      propertySet = find @propertySets, (set) -> set.selector.isEqual(selector)
+      if keyPath?
+      else
+        @propertySets.splice(@propertySets.indexOf(propertySet), 1)
+    @owner.layerDidUpdate(this)
+
+  # Public: Get an {Object} in the same format as the `propertiesBySelector`
+  # argument to {::set}, representing all of the {Layer}'s properties.
+  getPropertiesBySelector: ->
+    result = {}
+    for propertySet in @propertySets
+      result[propertySet.selector.toString()] = propertySet.properties
+    result
+
+  # Public: Remove the {Layer} from the cascade.
+  destroy: ->
+    @owner.layerDidDestroy(this)
+
+  # Public: Get an {Array} of all {PropertySet}s whose selectors match a scope.
+  #
+  # * `scopeChain` {String} See {ScopedPropertyStore::getPropertyValue}.
+  getPropertySets: (scopeChain) ->
+    result = []
+    for _, propertySet of @propertySets
+      if propertySet.selector.matches(scopeChain)
+        result.push(propertySet)
+    result

--- a/src/property-set.coffee
+++ b/src/property-set.coffee
@@ -1,22 +1,5 @@
-{deepExtend} = require 'underscore-plus'
-{hasKeyPath, getValueAtKeyPath} = require 'key-path-helpers'
-
+# Public: A set of properties associated with a {Selector}
 module.exports =
 class PropertySet
-  constructor: (@source, @selector, @properties) ->
-    @name = @source # Supports deprecated usage
-
-  matches: (scope) ->
-    @selector.matches(scope)
-
-  compare: (other) ->
-    @selector.compare(other.selector)
-
-  merge: (other) ->
-    new PropertySet(@source, @selector, deepExtend({}, other.properties, @properties))
-
-  has: (keyPath) ->
-    hasKeyPath(@properties, keyPath)
-
-  get: (keyPath) ->
-    getValueAtKeyPath(@properties, keyPath)
+  constructor: (@selector, @layer) ->
+    @properties = {}


### PR DESCRIPTION
This is motivated by atom/atom#4567 - improving the public interface of the atom `Config` object.
#### Context

Currently in Atom, the user's settings are not stored in the `ScopedPropertyStore`; they're stored in a separate mutable object. We want to move to storing _all_ of the settings in the scoped store.
#### Problem

With the way the `ScopedPropertyStore` currently works, every change to a setting (e.g. increasing/decreasing the editor font size) would require _adding_ a new entry to the cascade via `::addProperties`. This would increase the size of the object and slow down property value calculations over time.
#### Solution

I've reorganized the API of the `ScopedPropertyStore` so that it's based on mutable `Layers`. When you specifically want to add a new Layer, you add one via `::addLayer(name, {priority})`. When you want to _change_ the value of a setting in a given layer, you use `Layer::set(selector, keyPath, value)`.

Layers are kind of like what were previously called `sources` - the user can use them to manage properties associated with a particular file. The differences are:
- Layers reside at one spot in the cascade. Sources could be associated with multiple property sets at different positions.
- Layers' properties are mutable.

I think the word 'Layer' better tells the story that these objects represent entries in an ordered cascade. I still think that the Atom `Config` should use the word 'source', but since that word emphasizes the association with a _file_, it doesn't seem appropriate for the `ScopedPropertyStore` which doesn't necessarily know anything about files.
